### PR TITLE
Fixes and suppresses warnings about non existing function prototypes.

### DIFF
--- a/Component/Bezier.c
+++ b/Component/Bezier.c
@@ -1,5 +1,11 @@
 // http://www.flong.com/texts/code/shapers_bez/
 
+#import "Bezier.h"
+
+
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+
 // Helper functions:
 float slopeFromT (float t, float A, float B, float C){
 	float dtdx = 1.0/(3.0*A*t*t + 2.0*B*t + C);


### PR DESCRIPTION
In my current project, the modified class creates some warnings about missing function prototypes. In order to get rid of them, I imported the header file to fix the warning for the public function and added an ignore rule for the private functions. Another fix would be to make the private functions static... Please integrate this PR so that I get rid of the existing warnings.